### PR TITLE
Refactor take-over of supply locations

### DIFF
--- a/init.sqf
+++ b/init.sqf
@@ -21,7 +21,10 @@ tms_init_base_container = compile preprocessFileLineNumbers "tmscti\init_base_co
 tms_init_area_control_installation_container = compile preprocessFileLineNumbers "tmscti\init_area_control_installation_container.sqf";
 tms_get_nearest_object = compile preprocessFileLineNumbers "tmscti\helper_functions\get_nearest_object.sqf";
 tms_get_nearest_supply_location = compile preprocessFileLineNumbers "tmscti\helper_functions\get_nearest_supply_location.sqf";
+tms_get_near_supply_locations = compile preprocessFileLineNumbers "tmscti\helper_functions\get_near_supply_locations.sqf";
+tms_get_range_of_aci_type = compile preprocessFileLineNumbers "tmscti\helper_functions\get_range_of_aci_type.sqf";
 tms_activate_area_control_installation = compile preprocessFileLineNumbers "tmscti\activate_area_control_installation.sqf";
+tms_update_supply_location_side = compile preprocessFileLineNumbers "tmscti\update_supply_location_side.sqf";
 
 // TODO: Make configurable
 setViewDistance 4000;

--- a/tmscti/helper_functions/get_near_supply_locations.sqf
+++ b/tmscti/helper_functions/get_near_supply_locations.sqf
@@ -1,0 +1,22 @@
+/*
+Helper function that returns an array of all supply location within given radius around a point
+
+Parameter 0: Position on map
+Parameter 1: Radius in meters
+*/
+
+_position = _this select 0;
+_max_distance = _this select 1;
+
+_out = [];
+
+	{
+	_location = call compile _x;
+	_location_position = getMarkerPos (_location select tms_sl_cols_map_marker);
+	_current_distance = _location_position distance _position;
+	if (_current_distance < _max_distance) then {
+		_out pushBack _x;
+		};
+	} forEach tms_supply_locations;
+
+_out;

--- a/tmscti/helper_functions/get_nearest_supply_location.sqf
+++ b/tmscti/helper_functions/get_nearest_supply_location.sqf
@@ -3,14 +3,14 @@ _position = _this select 0;
 _nearest = nil;
 _nearest_distance = 100000;
 
-    {
+	{
 	_location = call compile _x;
 	_location_position = getMarkerPos (_location select 1);
-    _current_distance = _location_position distance _position;
-    if (_current_distance < _nearest_distance) then {
-        _nearest = _x;
-        _nearest_distance = _current_distance;
-        };
-    } forEach tms_supply_locations;
+	_current_distance = _location_position distance _position;
+	if (_current_distance < _nearest_distance) then {
+		_nearest = _x;
+		_nearest_distance = _current_distance;
+		};
+	} forEach tms_supply_locations;
 
 _nearest

--- a/tmscti/helper_functions/get_range_of_aci_type.sqf
+++ b/tmscti/helper_functions/get_range_of_aci_type.sqf
@@ -1,0 +1,9 @@
+_classname = _this select 0;
+
+_out = false;
+
+	{
+	if((_x select 0) == _classname) then {_out = _x select 1;}
+	} forEach tms_aci_types_west + tms_aci_types_east;
+
+_out;

--- a/tmscti/server/activate_area_control_installation.sqf
+++ b/tmscti/server/activate_area_control_installation.sqf
@@ -45,48 +45,13 @@ if(isServer) then {
 			};
 		};
 
-	_supply_location_variable = [position _installation] call tms_get_nearest_supply_location;
-	_supply_location = call compile _supply_location_variable;
-	_supply_location_position = getMarkerPos (_supply_location select tms_sl_cols_map_marker);
-	if (!(isNil '_supply_location' or (_supply_location_position distance _installation) > 100)) then {
-		// Check if the enemy has got any area control installations of their own in range, mark the location as contested if yes
-		_enemy_aci_types = nil;
-		if (_side == west) then {
-			_enemy_aci_types = tms_aci_types_east;
-			}
-		else {
-			_enemy_aci_types = tms_aci_types_west;
-		};
-		_enemy_aci_found = false; // Whether there is an enemy aci in range of this supply location
+	_aci_classname = typeOf _installation;
+	_aci_range = [_aci_classname] call tms_get_range_of_aci_type;
+	_supply_location_variables = [position _installation, _aci_range] call tms_get_near_supply_locations;
 		{
-			_enemy_acis = _supply_location_position nearObjects [_x select 0, _x select 1];
-			if (count _enemy_acis > 0) then {
-				_enemy_aci_found = true;
-				};
-		} foreach _enemy_aci_types;
-
-		if (not _enemy_aci_found) then {
-			_supply_location set [tms_sl_cols_side, _side];
-			publicVariable _supply_location_variable;
-			[
-				format ["We have taken over supply location %1.", _supply_location select tms_sl_cols_display_name],
-				"systemChat",
-				_side,
-				false
-			] call BIS_fnc_MP;
-			}
-		else {
-			_supply_location set [tms_sl_cols_side, independent];
-			publicVariable _supply_location_variable;
-			[
-				format ["Supply Location %1 is now contested.", _supply_location select tms_sl_cols_display_name],
-				"systemChat",
-				true,
-				false
-			] call BIS_fnc_MP;
-			};
-		};
-    }
+		[_x] call tms_update_supply_location_side;
+		} forEach _supply_location_variables;
+	}
 else {
 	hint "Tried to run server-side only function on non-server";
 	};

--- a/tmscti/update_supply_location_side.sqf
+++ b/tmscti/update_supply_location_side.sqf
@@ -1,0 +1,94 @@
+/*
+Checks which side should currently hold the given supply location and updates it accordingly
+
+Parameters:
+0: Name of the global variable describing the supply location in question
+*/
+
+_supply_location_variable = _this select 0;
+
+_supply_location = call compile _supply_location_variable;
+_supply_location_position = getMarkerPos (_supply_location select tms_sl_cols_map_marker);
+_old_side = _supply_location select tms_sl_cols_side;
+
+_west_aci_found = false; // Whether side west has an active aci in range of the location
+	{
+	_west_acis = _supply_location_position nearObjects [_x select 0, _x select 1];
+	if (count _west_acis > 0) then {
+		_west_aci_found = true;
+		};
+	} foreach tms_aci_types_west;
+	
+_east_aci_found = false; // Whether side east has an active aci in range of the location
+	{
+	_east_acis = _supply_location_position nearObjects [_x select 0, _x select 1];
+	if (count _east_acis > 0) then {
+		_east_aci_found = true;
+		};
+	} foreach tms_aci_types_east;
+
+if (_west_aci_found and (not _east_aci_found)) then {
+	if (_old_side != west) then {
+		_supply_location set [tms_sl_cols_side, west];
+		publicVariable _supply_location_variable;
+		[
+			format ["We have taken over supply location %1.", _supply_location select tms_sl_cols_display_name],
+			"systemChat",
+			west,
+			false
+		] call BIS_fnc_MP;
+		};
+	if (_old_side == east) then {
+		[
+			format ["We have lost supply location %1.", _supply_location select tms_sl_cols_display_name],
+			"systemChat",
+			east,
+			false
+		] call BIS_fnc_MP;
+		};
+	};
+
+if (_east_aci_found and (not _west_aci_found)) then {
+	if (_old_side != east) then {
+		_supply_location set [tms_sl_cols_side, east];
+		publicVariable _supply_location_variable;
+		[
+			format ["We have taken over supply location %1.", _supply_location select tms_sl_cols_display_name],
+			"systemChat",
+			east,
+			false
+		] call BIS_fnc_MP;
+		};
+	if (_old_side == west) then {
+		[
+			format ["We have lost supply location %1.", _supply_location select tms_sl_cols_display_name],
+			"systemChat",
+			west,
+			false
+		] call BIS_fnc_MP;
+		};
+	};
+
+if (_east_aci_found and _west_aci_found) then {
+	_supply_location set [tms_sl_cols_side, independent];
+	publicVariable _supply_location_variable;
+	[
+		format ["Supply Location %1 is now contested.", _supply_location select tms_sl_cols_display_name],
+		"systemChat",
+		true,
+		false
+	] call BIS_fnc_MP;
+	};
+
+if ((not _east_aci_found) and (not _west_aci_found)) then {
+	_supply_location set [tms_sl_cols_side, independent];
+	publicVariable _supply_location_variable;
+	if (_old_side != independent) then {
+		[
+			format ["Supply Location %1 is no longer controlled by anyone.", _supply_location select tms_sl_cols_display_name],
+			"systemChat",
+			_old_side,
+			false
+		] call BIS_fnc_MP;
+		};
+	};


### PR DESCRIPTION
Take over of supply locations is now determined by
update_supply_location_side.sqf. This should make it easier to recheck who
should own a supply location on other events, like an aci getting destroyed,
undeployed or even from a periodic timer while still using the exact same
decision logic.
